### PR TITLE
Mark atomic_reader_registry member funcs inline

### DIFF
--- a/include/mpm/leftright.h
+++ b/include/mpm/leftright.h
@@ -344,21 +344,21 @@ namespace mpm
     }
 
 
-    void
+    inline void
     atomic_reader_registry::arrive() noexcept
     {
         m_count.fetch_add(1, std::memory_order_acq_rel);
     }
 
 
-    void
+    inline void
     atomic_reader_registry::depart() noexcept
     {
         m_count.fetch_sub(1, std::memory_order_acq_rel);
     }
 
 
-    bool
+    inline bool
     atomic_reader_registry::empty() const noexcept
     {
         return 0 == m_count.load(std::memory_order_acquire);


### PR DESCRIPTION
These are not function templates and thus cause compilation errors if
they're not inline. Fixes GH-1.